### PR TITLE
Day36

### DIFF
--- a/SwiftUI/MyCode/iExpense/iExpense.xcodeproj/project.pbxproj
+++ b/SwiftUI/MyCode/iExpense/iExpense.xcodeproj/project.pbxproj
@@ -1,0 +1,344 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B87B819328EADF5B00230257 /* iExpenseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87B819228EADF5B00230257 /* iExpenseApp.swift */; };
+		B87B819528EADF5B00230257 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87B819428EADF5B00230257 /* ContentView.swift */; };
+		B87B819728EADF5B00230257 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B87B819628EADF5B00230257 /* Assets.xcassets */; };
+		B87B819A28EADF5B00230257 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B87B819928EADF5B00230257 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B87B818F28EADF5B00230257 /* iExpense.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iExpense.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B87B819228EADF5B00230257 /* iExpenseApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iExpenseApp.swift; sourceTree = "<group>"; };
+		B87B819428EADF5B00230257 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B87B819628EADF5B00230257 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B87B819928EADF5B00230257 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B87B818C28EADF5B00230257 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B87B818628EADF5B00230257 = {
+			isa = PBXGroup;
+			children = (
+				B87B819128EADF5B00230257 /* iExpense */,
+				B87B819028EADF5B00230257 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B87B819028EADF5B00230257 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B87B818F28EADF5B00230257 /* iExpense.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B87B819128EADF5B00230257 /* iExpense */ = {
+			isa = PBXGroup;
+			children = (
+				B87B819228EADF5B00230257 /* iExpenseApp.swift */,
+				B87B819428EADF5B00230257 /* ContentView.swift */,
+				B87B819628EADF5B00230257 /* Assets.xcassets */,
+				B87B819828EADF5B00230257 /* Preview Content */,
+			);
+			path = iExpense;
+			sourceTree = "<group>";
+		};
+		B87B819828EADF5B00230257 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				B87B819928EADF5B00230257 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B87B818E28EADF5B00230257 /* iExpense */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B87B819D28EADF5B00230257 /* Build configuration list for PBXNativeTarget "iExpense" */;
+			buildPhases = (
+				B87B818B28EADF5B00230257 /* Sources */,
+				B87B818C28EADF5B00230257 /* Frameworks */,
+				B87B818D28EADF5B00230257 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iExpense;
+			productName = iExpense;
+			productReference = B87B818F28EADF5B00230257 /* iExpense.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B87B818728EADF5B00230257 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1400;
+				LastUpgradeCheck = 1400;
+				TargetAttributes = {
+					B87B818E28EADF5B00230257 = {
+						CreatedOnToolsVersion = 14.0;
+					};
+				};
+			};
+			buildConfigurationList = B87B818A28EADF5B00230257 /* Build configuration list for PBXProject "iExpense" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B87B818628EADF5B00230257;
+			productRefGroup = B87B819028EADF5B00230257 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B87B818E28EADF5B00230257 /* iExpense */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B87B818D28EADF5B00230257 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B87B819A28EADF5B00230257 /* Preview Assets.xcassets in Resources */,
+				B87B819728EADF5B00230257 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B87B818B28EADF5B00230257 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B87B819528EADF5B00230257 /* ContentView.swift in Sources */,
+				B87B819328EADF5B00230257 /* iExpenseApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B87B819B28EADF5B00230257 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B87B819C28EADF5B00230257 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B87B819E28EADF5B00230257 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iExpense/Preview Content\"";
+				DEVELOPMENT_TEAM = D28AV23V6A;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = se.trafikappar.se.iExpense;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B87B819F28EADF5B00230257 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"iExpense/Preview Content\"";
+				DEVELOPMENT_TEAM = D28AV23V6A;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = se.trafikappar.se.iExpense;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B87B818A28EADF5B00230257 /* Build configuration list for PBXProject "iExpense" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B87B819B28EADF5B00230257 /* Debug */,
+				B87B819C28EADF5B00230257 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B87B819D28EADF5B00230257 /* Build configuration list for PBXNativeTarget "iExpense" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B87B819E28EADF5B00230257 /* Debug */,
+				B87B819F28EADF5B00230257 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B87B818728EADF5B00230257 /* Project object */;
+}

--- a/SwiftUI/MyCode/iExpense/iExpense.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SwiftUI/MyCode/iExpense/iExpense.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SwiftUI/MyCode/iExpense/iExpense.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwiftUI/MyCode/iExpense/iExpense.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SwiftUI/MyCode/iExpense/iExpense/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SwiftUI/MyCode/iExpense/iExpense/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/MyCode/iExpense/iExpense/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SwiftUI/MyCode/iExpense/iExpense/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/MyCode/iExpense/iExpense/Assets.xcassets/Contents.json
+++ b/SwiftUI/MyCode/iExpense/iExpense/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -1,0 +1,26 @@
+//
+//  ContentView.swift
+//  iExpense
+//
+//  Created by Oscar Fridh on 2022-10-03.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -7,13 +7,19 @@
 
 import SwiftUI
 
+struct User {
+    var firstName = "Bilbo"
+    var lastName = "Baggins"
+}
+
 struct ContentView: View {
+    @State private var user = User()
+    
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundColor(.accentColor)
-            Text("Hello, world!")
+            Text("Your name is \(user.firstName) \(user.lastName)")
+            TextField("First name", text: $user.firstName)
+            TextField("Last name", text: $user.lastName)
         }
         .padding()
     }

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -13,12 +13,11 @@ class User: ObservableObject {
 }
 
 struct ContentView: View {
-    @State private var tapCount = UserDefaults.standard.integer(forKey: "Tap")
+    @AppStorage("Tap") private var tapCount = 0
     
     var body: some View {
         Button("Tap count: \(tapCount)") {
             tapCount += 1
-            UserDefaults.standard.set(tapCount, forKey: "Tap")
         }
     }
 }

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -7,30 +7,34 @@
 
 import SwiftUI
 
-class User: ObservableObject {
-    @Published var firstName = "Bilbo"
-    @Published var lastName = "Baggins"
+struct User: Codable {
+    var firstName: String
+    var lastName: String
 }
 
 struct ContentView: View {
-    @AppStorage("Tap") private var tapCount = 0
-    
-    var body: some View {
-        Button("Tap count: \(tapCount)") {
-            tapCount += 1
+    @State private var user = {
+        if let data = UserDefaults.standard.data(forKey: "UserData") {
+            let decoder = JSONDecoder()
+            if let user = try? decoder.decode(User.self, from: data) {
+                return user
+            }
         }
-    }
-}
-
-struct SecondView: View {
-    let name: String
-    @Environment(\.dismiss) var dismiss
+        return User(firstName: "Taylor", lastName: "Swift")
+    }()
     
     var body: some View {
         VStack {
-            Text("Hello, \(name)!")
-            Button("Dismiss") {
-                dismiss()
+            Text("\(user.firstName) \(user.lastName)")
+            TextField("First name", text: $user.firstName)
+            TextField("Last name", text: $user.lastName)
+            
+            Button("Save User") {
+                let encoder = JSONEncoder()
+                
+                if let data = try? encoder.encode(user) {
+                    UserDefaults.standard.set(data, forKey: "UserData")
+                }
             }
         }
     }

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -13,32 +13,13 @@ class User: ObservableObject {
 }
 
 struct ContentView: View {
-    @State private var numbers = [Int]()
-    @State private var currentNumber = 1
+    @State private var tapCount = UserDefaults.standard.integer(forKey: "Tap")
     
     var body: some View {
-        NavigationView {
-            VStack {
-                List {
-                    ForEach(numbers, id: \.self) {
-                        Text("Row \($0)")
-                    }
-                    .onDelete(perform: removeRows)
-                }
-                
-                Button("Add Number") {
-                    numbers.append(currentNumber)
-                    currentNumber += 1
-                }
-            }
-            .toolbar {
-                EditButton()
-            }
+        Button("Tap count: \(tapCount)") {
+            tapCount += 1
+            UserDefaults.standard.set(tapCount, forKey: "Tap")
         }
-    }
-    
-    func removeRows(at offsets: IndexSet) {
-        numbers.remove(atOffsets: offsets)
     }
 }
 

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -13,15 +13,32 @@ class User: ObservableObject {
 }
 
 struct ContentView: View {
-    @State private var showingSheet = false
+    @State private var numbers = [Int]()
+    @State private var currentNumber = 1
     
     var body: some View {
-        Button("Show sheet") {
-            showingSheet.toggle()
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(numbers, id: \.self) {
+                        Text("Row \($0)")
+                    }
+                    .onDelete(perform: removeRows)
+                }
+                
+                Button("Add Number") {
+                    numbers.append(currentNumber)
+                    currentNumber += 1
+                }
+            }
+            .toolbar {
+                EditButton()
+            }
         }
-        .sheet(isPresented: $showingSheet) {
-            SecondView(name: "Oscar")
-        }
+    }
+    
+    func removeRows(at offsets: IndexSet) {
+        numbers.remove(atOffsets: offsets)
     }
 }
 

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -7,13 +7,13 @@
 
 import SwiftUI
 
-struct User {
-    var firstName = "Bilbo"
-    var lastName = "Baggins"
+class User: ObservableObject {
+    @Published var firstName = "Bilbo"
+    @Published var lastName = "Baggins"
 }
 
 struct ContentView: View {
-    @State private var user = User()
+    @StateObject var user = User()
     
     var body: some View {
         VStack {

--- a/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/ContentView.swift
@@ -13,15 +13,29 @@ class User: ObservableObject {
 }
 
 struct ContentView: View {
-    @StateObject var user = User()
+    @State private var showingSheet = false
+    
+    var body: some View {
+        Button("Show sheet") {
+            showingSheet.toggle()
+        }
+        .sheet(isPresented: $showingSheet) {
+            SecondView(name: "Oscar")
+        }
+    }
+}
+
+struct SecondView: View {
+    let name: String
+    @Environment(\.dismiss) var dismiss
     
     var body: some View {
         VStack {
-            Text("Your name is \(user.firstName) \(user.lastName)")
-            TextField("First name", text: $user.firstName)
-            TextField("Last name", text: $user.lastName)
+            Text("Hello, \(name)!")
+            Button("Dismiss") {
+                dismiss()
+            }
         }
-        .padding()
     }
 }
 

--- a/SwiftUI/MyCode/iExpense/iExpense/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SwiftUI/MyCode/iExpense/iExpense/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/MyCode/iExpense/iExpense/iExpenseApp.swift
+++ b/SwiftUI/MyCode/iExpense/iExpense/iExpenseApp.swift
@@ -1,0 +1,17 @@
+//
+//  iExpenseApp.swift
+//  iExpense
+//
+//  Created by Oscar Fridh on 2022-10-03.
+//
+
+import SwiftUI
+
+@main
+struct iExpenseApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
Day 36

- The `@State` modifier observes changes to update affected views. This is why it only works with structs since the entire struct gets recreated on a modification. Changes to classes are undetected as the reference did not change.
- In order to share states between views, we can use the `@StateObject` modifier on a class that implements `@ObservableObject`. This object can contain properties marked with the `@Published` modifier. SwiftUI observes changes to these properties and updates affected views. Use `@StateObject` for ownership and `@ObservedObject` for other views.
- Views can be hidden and shown using a sheet modifier. The shown view does not need to know it's being presented in a sheet. It can access a dismiss instance from the environment to dismiss itself. This Dismiss instance is actually a struct that can be called as a method with no arguments.
- SwiftUI makes it super easy to implement deletable rows using the onDelete modifier. This modifier is attached on a ForEach inside of a List. To further enhance the user experience, we can add a toolbar with an Edit button.
- User defaults can be used in SwiftUI. For simple cases, use the `@AppState` modifier.